### PR TITLE
Fix problem with append datapoint with same date and price as latest datapoint

### DIFF
--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -65,6 +65,12 @@ class Scraper:
         product_info["info"].update(
             {"url": short_url, "id": product_id, "currency": self.info.currency}
         )
-        product_info["datapoints"].append({"date": date, "price": self.info.price})
+
+        latest_datapoint = product_info["datapoints"][-1]
+
+        if latest_datapoint["date"] == date:
+            latest_datapoint["price"] = self.info.price
+        else:
+            product_info["datapoints"].append({"date": date, "price": self.info.price})
 
         return data


### PR DESCRIPTION
Can now scrape multiple times the same day without append the same datapoint, now just updates the price in the lastest datapoint if the lastest datapoint's date is the same date as today