### PR TITLE
Update method BaseWebsiteHandler._request_product_data to not return a value

### DIFF
--- a/tests/test_website_handlers.py
+++ b/tests/test_website_handlers.py
@@ -20,88 +20,88 @@ from scraper.format import Info
 
 
 komplett_handler = KomplettHandler("https://www.komplett.dk/product/1168438")
-komplett_soup = komplett_handler._request_product_data()
-komplett_handler._get_common_data(komplett_soup)
+komplett_handler._request_product_data()
+komplett_handler._get_common_data()
 
 proshop_handler = ProshopHandler("https://www.proshop.dk/Hovedtelefonerheadset/Sony-WH-1000XM4/2883832")
-proshop_soup = proshop_handler._request_product_data()
-proshop_handler._get_common_data(proshop_soup)
+proshop_handler._request_product_data()
+proshop_handler._get_common_data()
 
 computersalg_handler = ComputerSalgHandler(
     "https://www.computersalg.dk/i/6647865/sony-wh-1000xm4-hovedtelefoner-med-mik-fuld-st%c3%b8rrelse-bluetooth-tr%c3%a5dl%c3%b8s-kabling-nfc-aktiv-st%c3%b8jfjerning-3-5-mm-jackstik-sort"
 )
-computersalg_soup = computersalg_handler._request_product_data()
-computersalg_handler._get_common_data(computersalg_soup)
+computersalg_handler._request_product_data()
+computersalg_handler._get_common_data()
 
 elgiganten_handler = ElgigantenHandler(
     "https://www.elgiganten.dk/product/tv-lyd-smart-home/horetelefoner-tilbehor/horetelefoner/sony-tradlose-around-ear-horetelefoner-wh-1000xm4-sort/200693"
 )
-elgiganten_soup = elgiganten_handler._request_product_data()
-elgiganten_handler._get_common_data(elgiganten_soup)
+elgiganten_handler._request_product_data()
+elgiganten_handler._get_common_data()
 
 avxperten_handler = AvXpertenHandler(
     "https://www.avxperten.dk/noise-cancelling-head-set/sony-wh-1000xm4-bluetooth-hovedtelefoner-anc-sort.asp"
 )
-avxperten_soup = avxperten_handler._request_product_data()
-avxperten_handler._get_common_data(avxperten_soup)
+avxperten_handler._request_product_data()
+avxperten_handler._get_common_data()
 
 avcables_handler = AvCablesHandler(
     "https://www.av-cables.dk/bluetooth-hoeretelefoner/sony-wh-1000xm4-over-ear-bluetooth-headset-sort.html"
 )
-avcables_soup = avcables_handler._request_product_data()
-avcables_handler._get_common_data(avcables_soup)
+avcables_handler._request_product_data()
+avcables_handler._get_common_data()
 
 amazon_handler = AmazonHandler(
     "https://www.amazon.com/Sony-WH-1000XM4-Wireless-Canceling-Headphones/dp/B08HDKHSSN/ref=sr_1_3?crid=2QKY9WQGCV809&keywords=sony+xm4&qid=1660593858&sprefix=sony+xm%2Caps%2C171&sr=8-3"
 )
-amazon_soup = amazon_handler._request_product_data()
-amazon_handler._get_common_data(amazon_soup)
+amazon_handler._request_product_data()
+amazon_handler._get_common_data()
 
 # for url that start with 'ebay.com/itm/'
 ebay_handler_with_item = EbayHandler("https://www.ebay.com/itm/265771092654")
-ebay_soup_with_itm = ebay_handler_with_item._request_product_data()
-ebay_handler_with_item._get_common_data(ebay_soup_with_itm)
+ebay_handler_with_item._request_product_data()
+ebay_handler_with_item._get_common_data()
 
 # for url that start with 'ebay.com/p/'
 ebay_handler_with_p = EbayHandler("https://www.ebay.com/p/1248083754?iid=181677611772&rt=nc")
-ebay_soup_with_p = ebay_handler_with_p._request_product_data()
-ebay_handler_with_p._get_common_data(ebay_soup_with_p)
+ebay_handler_with_p._request_product_data()
+ebay_handler_with_p._get_common_data()
 
 expert_handler = ExpertHandler(
     "https://www.expert.dk/hoejtalere-og-lyd/hovedtelefoner/traadloese-hovedtelefoner/sony-wh-1000xm4-traadloese-stoejdaempende-hovedtelefoner-sort/p-1106907/"
 )
-expert_soup = expert_handler._request_product_data()
-expert_handler._get_common_data(expert_soup)
+expert_handler._request_product_data()
+expert_handler._get_common_data()
 
 power_handler = PowerHandler(
     "https://www.power.dk/tv-og-lyd/hovedtelefoner/traadloese-hovedtelefoner/sony-wh-1000xm4-traadloese-stoejdaempende-hovedtelefoner-blaa/p-1185731/"
 )
-power_soup = power_handler._request_product_data()
-power_handler._get_common_data(power_soup)
+power_handler._request_product_data()
+power_handler._get_common_data()
 
 mmvision_handler = MMVisionHandler("https://www.mm-vision.dk/asus-zenbook-duo-14-ux482eg-pure9x-baerbar")
-mmvision_soup = mmvision_handler._request_product_data()
-mmvision_handler._get_common_data(mmvision_soup)
+mmvision_handler._request_product_data()
+mmvision_handler._get_common_data()
 
 coolshop_handler = CoolshopHandler("https://www.coolshop.dk/produkt/pokemon-brilliant-diamond/238G6U/")
-coolshop_soup = coolshop_handler._request_product_data()
-coolshop_handler._get_common_data(coolshop_soup)
+coolshop_handler._request_product_data()
+coolshop_handler._get_common_data()
 
 sharkgaming_handler = SharkGamingHandler("https://sharkgaming.dk/asus-gladius-ii-origin-gaming-mouse")
-sharkgaming_soup = sharkgaming_handler._request_product_data()
-sharkgaming_handler._get_common_data(sharkgaming_soup)
+sharkgaming_handler._request_product_data()
+sharkgaming_handler._get_common_data()
 
 newegg_handler = NeweggHandler(
     "https://www.newegg.com/sony-wh1000xm4b-bluetooth-headset-black/p/0G6-001C-00614?Description=sony%20xm4&cm_re=sony_xm4-_-0G6-001C-00614-_-Product&quicklink=true"
 )
-newegg_soup = newegg_handler._request_product_data()
-newegg_handler._get_common_data(newegg_soup)
+newegg_handler._request_product_data()
+newegg_handler._get_common_data()
 
 hifiklubben_handler = HifiKlubbenHandler(
     "https://www.hifiklubben.dk/sennheiser-momentum-4-wireless-hoeretelefoner/senmomentum4bk/"
 )
-hifiklubben_soup = hifiklubben_handler._request_product_data()
-hifiklubben_handler._get_common_data(hifiklubben_soup)
+hifiklubben_handler._request_product_data()
+hifiklubben_handler._get_common_data()
 
 
 class BaseTestWebsiteHandler(ABC):
@@ -128,196 +128,196 @@ class BaseTestWebsiteHandler(ABC):
 
 class TestKomplettHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=komplett_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=komplett_handler.request_data)
         actual = komplett_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = komplett_handler._get_product_name(komplett_soup).lower()
+        actual = komplett_handler._get_product_name().lower()
         expected = "ASUS GeForce RTX 3090 ROG Strix OC".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = komplett_handler._get_product_price(komplett_soup)
+        price = komplett_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = komplett_handler._get_product_currency(komplett_soup)
+        currency = komplett_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = komplett_handler._get_product_id(komplett_soup)
+        id = komplett_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "1168438"
 
 
 class TestProshopHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=proshop_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=proshop_handler.request_data)
         actual = proshop_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = proshop_handler._get_product_name(proshop_soup).lower()
+        actual = proshop_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = proshop_handler._get_product_price(proshop_soup)
+        price = proshop_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = proshop_handler._get_product_currency(proshop_soup)
+        currency = proshop_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = proshop_handler._get_product_id(proshop_soup)
+        id = proshop_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "2883832"
 
 
 class TestComputersalgHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=computersalg_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=computersalg_handler.request_data)
         actual = computersalg_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = computersalg_handler._get_product_name(computersalg_soup).lower()
+        actual = computersalg_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4 - Hovedtelefoner med mik. - fuld størrelse - Bluetooth - trådløs, kabling - NFC - aktiv støjfjerning - 3,5 mm jackstik - sort".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = computersalg_handler._get_product_price(computersalg_soup)
+        price = computersalg_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = computersalg_handler._get_product_currency(computersalg_soup)
+        currency = computersalg_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = computersalg_handler._get_product_id(computersalg_soup)
+        id = computersalg_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "6647865"
 
 
 class TestElgigantenHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=elgiganten_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=elgiganten_handler.request_data)
         actual = elgiganten_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = elgiganten_handler._get_product_name(elgiganten_soup).lower()
+        actual = elgiganten_handler._get_product_name().lower()
         expected = "Sony trådløse around-ear høretelefoner WH-1000XM4 (sort)".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = elgiganten_handler._get_product_price(elgiganten_soup)
+        price = elgiganten_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = elgiganten_handler._get_product_currency(elgiganten_soup)
+        currency = elgiganten_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = elgiganten_handler._get_product_id(elgiganten_soup)
+        id = elgiganten_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "200693"
 
 
 class TestAvXpertenHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=avxperten_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=avxperten_handler.request_data)
         actual = avxperten_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = avxperten_handler._get_product_name(avxperten_soup).lower()
+        actual = avxperten_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4 Bluetooth hovedtelefoner (m/ANC) Sort".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = avxperten_handler._get_product_price(avxperten_soup)
+        price = avxperten_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = avxperten_handler._get_product_currency(avxperten_soup)
+        currency = avxperten_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = avxperten_handler._get_product_id(avxperten_soup)
+        id = avxperten_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "33590"
 
 
 class TestAvCablesHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=avcables_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=avcables_handler.request_data)
         actual = avcables_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = avcables_handler._get_product_name(avcables_soup).lower()
+        actual = avcables_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4 Over-Ear Bluetooth Headset - Sort".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = avcables_handler._get_product_price(avcables_soup)
+        price = avcables_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = avcables_handler._get_product_currency(avcables_soup)
+        currency = avcables_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = avcables_handler._get_product_id(avcables_soup)
+        id = avcables_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "833015"
 
 
 class TestAmazonHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=amazon_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=amazon_handler.request_data)
         actual = amazon_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = amazon_handler._get_product_name(amazon_soup).lower()
+        actual = amazon_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4 Wireless Noise Canceling Overhead Headphones - Black (Renewed)".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = amazon_handler._get_product_price(amazon_soup)
+        price = amazon_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = amazon_handler._get_product_currency(amazon_soup)
+        currency = amazon_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "USD"
 
     def test_get_id(self):
-        id = amazon_handler._get_product_id(amazon_soup)
+        id = amazon_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "B08HDKHSSN"
 
@@ -325,29 +325,29 @@ class TestAmazonHandler(BaseTestWebsiteHandler):
 # OBS: There is two Ebay versions - This is for url that start with 'ebay.com/itm/'
 class TestEbayHandler_with_itm(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=ebay_soup_with_itm)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=ebay_handler_with_item.request_data)
         actual = ebay_handler_with_item.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = ebay_handler_with_item._get_product_name(ebay_soup_with_itm).lower()
+        actual = ebay_handler_with_item._get_product_name().lower()
         expected = "BRAND NEW Sony PS5 Playstation 5 Blu-Ray Disc Edition Console  -Fast Delivery".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = ebay_handler_with_item._get_product_price(ebay_soup_with_itm)
+        price = ebay_handler_with_item._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = ebay_handler_with_item._get_product_currency(ebay_soup_with_itm)
+        currency = ebay_handler_with_item._get_product_currency()
         assert isinstance(currency, str)
         assert len(currency) == 3
         assert currency == "USD"
 
     def test_get_id(self):
-        id = ebay_handler_with_item._get_product_id(ebay_soup_with_itm)
+        id = ebay_handler_with_item._get_product_id()
         assert isinstance(id, str)
         assert id == "265771092654"
 
@@ -355,224 +355,224 @@ class TestEbayHandler_with_itm(BaseTestWebsiteHandler):
 # OBS: There is two Ebay versions - This is for url that start with 'ebay.com/p/'
 class TestEbayHandler_with_p(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=ebay_soup_with_p)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=ebay_handler_with_p.request_data)
         actual = ebay_handler_with_p.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = ebay_handler_with_p._get_product_name(ebay_soup_with_p).lower()
+        actual = ebay_handler_with_p._get_product_name().lower()
         expected = "Etude House Collagen Eye Patch Korea Cosmetics 10 Sheets".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = ebay_handler_with_p._get_product_price(ebay_soup_with_p)
+        price = ebay_handler_with_p._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = ebay_handler_with_p._get_product_currency(ebay_soup_with_p)
+        currency = ebay_handler_with_p._get_product_currency()
         assert isinstance(currency, str)
         assert len(currency) == 3
         # assert currency == "DKK"
 
     def test_get_id(self):
-        id = ebay_handler_with_p._get_product_id(ebay_soup_with_p)
+        id = ebay_handler_with_p._get_product_id()
         assert isinstance(id, str)
         assert id == "181677611772"
 
 
 class TestPowerHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=power_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=power_handler.request_data)
         actual = power_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = power_handler._get_product_name(power_soup).lower()
+        actual = power_handler._get_product_name().lower()
         expected = "SONY WH-1000XM4 TRÅDLØSE STØJDÆMPENDE HOVEDTELEFONER BLÅ".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = power_handler._get_product_price(power_soup)
+        price = power_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = power_handler._get_product_currency(power_soup)
+        currency = power_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = power_handler._get_product_id(power_soup)
+        id = power_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "1185731"
 
 
 class TestExpertHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=expert_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=expert_handler.request_data)
         actual = expert_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = expert_handler._get_product_name(expert_soup).lower()
+        actual = expert_handler._get_product_name().lower()
         expected = "SONY WH-1000XM4 TRÅDLØSE STØJDÆMPENDE HOVEDTELEFONER SORT".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = expert_handler._get_product_price(expert_soup)
+        price = expert_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = expert_handler._get_product_currency(expert_soup)
+        currency = expert_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = expert_handler._get_product_id(expert_soup)
+        id = expert_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "1106907"
 
 
 class TestMMVisionHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=mmvision_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=mmvision_handler.request_data)
         actual = mmvision_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = mmvision_handler._get_product_name(mmvision_soup).lower()
+        actual = mmvision_handler._get_product_name().lower()
         expected = "Asus ZenBook Duo 14 UX482".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = mmvision_handler._get_product_price(mmvision_soup)
+        price = mmvision_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = mmvision_handler._get_product_currency(mmvision_soup)
+        currency = mmvision_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = mmvision_handler._get_product_id(mmvision_soup)
+        id = mmvision_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "6987132"
 
 
 class TestCoolshopHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=coolshop_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=coolshop_handler.request_data)
         actual = coolshop_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = coolshop_handler._get_product_name(coolshop_soup).lower()
+        actual = coolshop_handler._get_product_name().lower()
         expected = "Pokemon Brilliant Diamond - Nintendo Switch".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = coolshop_handler._get_product_price(coolshop_soup)
+        price = coolshop_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = coolshop_handler._get_product_currency(coolshop_soup)
+        currency = coolshop_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = coolshop_handler._get_product_id(coolshop_soup)
+        id = coolshop_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "1177871"
 
 
 class TestSharkGamingHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=sharkgaming_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=sharkgaming_handler.request_data)
         actual = sharkgaming_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = sharkgaming_handler._get_product_name(sharkgaming_soup).lower()
+        actual = sharkgaming_handler._get_product_name().lower()
         expected = "ASUS Gladius II Origin gaming mouse".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = sharkgaming_handler._get_product_price(sharkgaming_soup)
+        price = sharkgaming_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = sharkgaming_handler._get_product_currency(sharkgaming_soup)
+        currency = sharkgaming_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = sharkgaming_handler._get_product_id(sharkgaming_soup)
+        id = sharkgaming_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "90MP00U1-B0UA00"
 
 
 class TestNeweggHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=newegg_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=newegg_handler.request_data)
         actual = newegg_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = newegg_handler._get_product_name(newegg_soup).lower()
+        actual = newegg_handler._get_product_name().lower()
         expected = "Sony WH-1000XM4 Wireless Noise-Cancelling Over-Ear Headphones (Black)".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = newegg_handler._get_product_price(newegg_soup)
+        price = newegg_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = newegg_handler._get_product_currency(newegg_soup)
+        currency = newegg_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "USD"
 
     def test_get_id(self):
-        id = newegg_handler._get_product_id(newegg_soup)
+        id = newegg_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "0G6-001C-00614"
 
 
 class TestHifiKlubbenHandler(BaseTestWebsiteHandler):
     def test_get_product_info(self, mocker):
-        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=hifiklubben_soup)
+        mocker.patch("scraper.domains.BaseWebsiteHandler._request_product_data", return_value=hifiklubben_handler.request_data)
         actual = hifiklubben_handler.get_product_info()
         assert isinstance(actual, Info)
         assert actual.valid
 
     def test_get_name(self):
-        actual = hifiklubben_handler._get_product_name(hifiklubben_soup).lower()
+        actual = hifiklubben_handler._get_product_name().lower()
         expected = "SENNHEISER MOMENTUM 4 WIRELESS".lower()
         assert isinstance(actual, str)
         assert actual == expected
 
     def test_get_price(self):
-        price = hifiklubben_handler._get_product_price(hifiklubben_soup)
+        price = hifiklubben_handler._get_product_price()
         assert isinstance(price, float)
 
     def test_get_currency(self):
-        currency = hifiklubben_handler._get_product_currency(hifiklubben_soup)
+        currency = hifiklubben_handler._get_product_currency()
         assert isinstance(currency, str)
         assert currency == "DKK"
 
     def test_get_id(self):
-        id = hifiklubben_handler._get_product_id(hifiklubben_soup)
+        id = hifiklubben_handler._get_product_id()
         assert isinstance(id, str)
         assert id == "senmomentum4bk"


### PR DESCRIPTION
Update method BaseWebsiteHandler._request_data:
- Save the request data as a instance variable "self.request_data" instead of return the request_data (request_data might need to be renamed)

Delete parameters "soup" in the following methods in all website handlers:
- _get_common_data
- _get_product_name
- _get_product_price
- _get_product_currency
- _get_product_id

Update website handlers tests to reflect changes