### PR TITLE
Optimize scraping with threads

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,7 +61,8 @@ def scrape_with_threads() -> None:
 
     request_delay = scraper.Config.get_request_delay()
 
-    domain_grouped_products_df = scraper.get_products_df_grouped_by_domains()
+    products_df = scraper.Filemanager.get_products_data()
+    domain_grouped_products_df = scraper.get_products_df_grouped_by_domains(products_df)
     grouped_products = scraper.get_products_grouped_by_domain(domain_grouped_products_df)
 
     grouped_scraper_threads: List[List[threading.Thread]] = []

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def scrape_with_threads():
         scraper_threads = [threading.Thread(target=product.scrape_info) for product in products]
         grouped_scraper_threads.append(scraper_threads)
 
-    # Create master threads to start scraper threads sequentially for each domain
+    # Create master threads to manage scraper threads sequentially for each domain
     master_threads = [
         threading.Thread(target=scraper.start_threads_sequentially, args=[scraper_threads, request_delay])
         for scraper_threads in grouped_scraper_threads

--- a/main.py
+++ b/main.py
@@ -62,7 +62,6 @@ def scrape_with_threads():
     request_delay = scraper.Config.get_request_delay()
 
     domain_grouped_products_df = scraper.get_products_df_grouped_by_domains()
-
     grouped_products = scraper.get_products_grouped_by_domain(domain_grouped_products_df)
 
     grouped_scraper_threads: List[List[threading.Thread]] = []

--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -7,7 +7,7 @@ from .clean_data import clean_records_data
 from .delete_data import delete
 from .reset_data import reset
 from .search_data import search
-from .misc import print_latest_datapoints, print_all_products
+from .print_products import print_latest_datapoints, print_all_products
 
 
 __author__ = "Crinibus"

--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -1,4 +1,4 @@
-from .scrape import Scraper
+from .scrape import Scraper, start_threads_sequentially
 from .arguments import argparse_setup
 from .add_product import add_products
 from .filemanager import Filemanager, Config
@@ -8,6 +8,7 @@ from .delete_data import delete
 from .reset_data import reset
 from .search_data import search
 from .print_products import print_latest_datapoints, print_all_products
+from .misc import get_products_df_grouped_by_domains, get_products_grouped_by_domain
 
 
 __author__ = "Crinibus"

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -30,5 +30,7 @@ def get_products_grouped_by_domain(grouped_products_df: DataFrameGroupBy) -> Dic
 
     for domain_name in grouped_products_df.groups:
         group_products = grouped_products_df.get_group(domain_name)
-        domains_dict[domain_name] = [Scraper(category, url) for category, url in zip(group_products["category"], group_products["url"])]
+        domains_dict[domain_name] = [
+            Scraper(category, url) for category, url in zip(group_products["category"], group_products["url"])
+        ]
     return domains_dict

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -1,4 +1,3 @@
-from typing import Dict, List
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
@@ -6,7 +5,7 @@ from scraper.scrape import Scraper
 from scraper.domains import get_website_name
 
 
-def add_dataframe_column(df: pd.DataFrame, column_name: str, column_data: List[any]) -> pd.DataFrame:
+def add_dataframe_column(df: pd.DataFrame, column_name: str, column_data: list[any]) -> pd.DataFrame:
     df[column_name] = column_data
     return df
 
@@ -23,8 +22,8 @@ def get_products_df_grouped_by_domains(products_df: pd.DataFrame) -> DataFrameGr
     return grouped_df
 
 
-def get_products_grouped_by_domain(grouped_products_df: DataFrameGroupBy) -> Dict[str, List[Scraper]]:
-    domains_dict: Dict[str, List[Scraper]] = {}
+def get_products_grouped_by_domain(grouped_products_df: DataFrameGroupBy) -> dict[str, list[Scraper]]:
+    domains_dict: dict[str, list[Scraper]] = {}
 
     for domain_name in grouped_products_df.groups:
         group_products = grouped_products_df.get_group(domain_name)

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Dict, List
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
+from scraper.scrape import Scraper
 from scraper.filemanager import Filemanager
 from scraper.domains import get_website_name
 
@@ -22,3 +23,12 @@ def get_products_df_grouped_by_domains() -> DataFrameGroupBy:
     df = add_dataframe_column(product_df, "domain", domain_names)
     grouped_df = group_df(df, "domain", True)
     return grouped_df
+
+
+def get_products_grouped_by_domain(grouped_products_df: DataFrameGroupBy) -> Dict[str, List[Scraper]]:
+    domains_dict: Dict[str, List[Scraper]] = {}
+
+    for domain_name in grouped_products_df.groups:
+        group_products = grouped_products_df.get_group(domain_name)
+        domains_dict[domain_name] = [Scraper(category, url) for category, url in zip(group_products["category"], group_products["url"])]
+    return domains_dict

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -1,8 +1,24 @@
+from typing import List
+import pandas as pd
+from pandas.core.groupby.generic import DataFrameGroupBy
 
 from scraper.filemanager import Filemanager
+from scraper.domains import get_website_name
 
 
+def add_dataframe_column(df: pd.DataFrame, column_name: str, column_data: List[any]) -> pd.DataFrame:
+    df[column_name] = column_data
+    return df
 
 
+def group_df(df: pd.DataFrame, column_name: str, group_keys: bool) -> DataFrameGroupBy:
+    grouped_df = df.groupby(column_name, group_keys=group_keys)
+    return grouped_df
 
 
+def get_products_df_grouped_by_domains() -> DataFrameGroupBy:
+    product_df = Filemanager.get_products_data()
+    domain_names = [get_website_name(url) for url in product_df["url"]]
+    df = add_dataframe_column(product_df, "domain", domain_names)
+    grouped_df = group_df(df, "domain", True)
+    return grouped_df

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -1,64 +1,8 @@
-from typing import Iterator, List, Tuple
 
 from scraper.filemanager import Filemanager
 
 
-def print_latest_datapoints(names: List[str], ids: List[str]):
-    records_data = Filemanager.get_record_data()
-
-    if names:
-        print("\n----- SHOWING LATEST DATAPOINT FOR NAME(s) -----")
-        for name in names:
-            print(name.upper())
-            # iterate the different websites the product with the specified name is scraped from
-            for website_name, website_dict in get_product_info_with_name(name, records_data):
-                print_latest_datapoint(website_name, website_dict)
-            print()
-
-    if ids:
-        print("\n----- SHOWING LATEST DATAPOINT FOR ID(s) -----")
-        for id in ids:
-            product_name, website_name, website_dict = get_product_info_with_id(id, records_data)
-            print(product_name.upper())
-            print_latest_datapoint(website_name, website_dict)
-            print()
 
 
-def get_product_info_with_name(name: str, records_data: dict) -> Iterator[Tuple[str, str, dict]]:
-    for category_dict in records_data.values():
-        for product_name, product_dict in category_dict.items():
-            if not product_name.lower() == name.lower():
-                continue
-            for website_name, website_dict in product_dict.items():
-                yield website_name, website_dict
 
 
-def get_product_info_with_id(id: str, records_data: dict) -> Tuple[str, str, dict]:
-    for category_dict in records_data.values():
-        for product_name, product_dict in category_dict.items():
-            for website_name, website_dict in product_dict.items():
-                if website_dict["info"]["id"] == id:
-                    return product_name, website_name, website_dict
-
-
-def print_latest_datapoint(website_name: str, website_dict: dict) -> None:
-    id = website_dict["info"]["id"]
-    currency = website_dict["info"]["currency"]
-    latest_datapoint = website_dict["datapoints"][-1]
-    date = latest_datapoint["date"]
-    price = latest_datapoint["price"]
-    print(f"> {website_name.capitalize()} - {id}\n  - {currency} {price}\n  - {date}")
-
-
-def print_all_products():
-    records_data = Filemanager.get_record_data()
-
-    print("\n----- SHOWING ALL PRODUCTS -----")
-    for category_name, category_dict in records_data.items():
-        print(category_name.upper())
-        for product_name, product_dict in category_dict.items():
-            print(f"  > {product_name.upper()}")
-            for website_name, website_dict in product_dict.items():
-                product_id = website_dict["info"]["id"]
-                print(f"    - {website_name.upper()} - {product_id}")
-    print()

--- a/scraper/misc.py
+++ b/scraper/misc.py
@@ -3,7 +3,6 @@ import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
 from scraper.scrape import Scraper
-from scraper.filemanager import Filemanager
 from scraper.domains import get_website_name
 
 
@@ -17,10 +16,9 @@ def group_df(df: pd.DataFrame, column_name: str, group_keys: bool) -> DataFrameG
     return grouped_df
 
 
-def get_products_df_grouped_by_domains() -> DataFrameGroupBy:
-    product_df = Filemanager.get_products_data()
-    domain_names = [get_website_name(url) for url in product_df["url"]]
-    df = add_dataframe_column(product_df, "domain", domain_names)
+def get_products_df_grouped_by_domains(products_df: pd.DataFrame) -> DataFrameGroupBy:
+    domain_names = [get_website_name(url) for url in products_df["url"]]
+    df = add_dataframe_column(products_df, "domain", domain_names)
     grouped_df = group_df(df, "domain", True)
     return grouped_df
 

--- a/scraper/print_products.py
+++ b/scraper/print_products.py
@@ -3,7 +3,7 @@ from typing import Iterator, List, Tuple
 from scraper.filemanager import Filemanager
 
 
-def print_latest_datapoints(names: List[str], ids: List[str]):
+def print_latest_datapoints(names: List[str], ids: List[str]) -> None:
     records_data = Filemanager.get_record_data()
 
     if names:
@@ -50,7 +50,7 @@ def print_latest_datapoint(website_name: str, website_dict: dict) -> None:
     print(f"> {website_name.capitalize()} - {id}\n  - {currency} {price}\n  - {date}")
 
 
-def print_all_products():
+def print_all_products() -> None:
     records_data = Filemanager.get_record_data()
 
     print("\n----- SHOWING ALL PRODUCTS -----")

--- a/scraper/print_products.py
+++ b/scraper/print_products.py
@@ -1,0 +1,64 @@
+from typing import Iterator, List, Tuple
+
+from scraper.filemanager import Filemanager
+
+
+def print_latest_datapoints(names: List[str], ids: List[str]):
+    records_data = Filemanager.get_record_data()
+
+    if names:
+        print("\n----- SHOWING LATEST DATAPOINT FOR NAME(s) -----")
+        for name in names:
+            print(name.upper())
+            # iterate the different websites the product with the specified name is scraped from
+            for website_name, website_dict in get_product_info_with_name(name, records_data):
+                print_latest_datapoint(website_name, website_dict)
+            print()
+
+    if ids:
+        print("\n----- SHOWING LATEST DATAPOINT FOR ID(s) -----")
+        for id in ids:
+            product_name, website_name, website_dict = get_product_info_with_id(id, records_data)
+            print(product_name.upper())
+            print_latest_datapoint(website_name, website_dict)
+            print()
+
+
+def get_product_info_with_name(name: str, records_data: dict) -> Iterator[Tuple[str, str, dict]]:
+    for category_dict in records_data.values():
+        for product_name, product_dict in category_dict.items():
+            if not product_name.lower() == name.lower():
+                continue
+            for website_name, website_dict in product_dict.items():
+                yield website_name, website_dict
+
+
+def get_product_info_with_id(id: str, records_data: dict) -> Tuple[str, str, dict]:
+    for category_dict in records_data.values():
+        for product_name, product_dict in category_dict.items():
+            for website_name, website_dict in product_dict.items():
+                if website_dict["info"]["id"] == id:
+                    return product_name, website_name, website_dict
+
+
+def print_latest_datapoint(website_name: str, website_dict: dict) -> None:
+    id = website_dict["info"]["id"]
+    currency = website_dict["info"]["currency"]
+    latest_datapoint = website_dict["datapoints"][-1]
+    date = latest_datapoint["date"]
+    price = latest_datapoint["price"]
+    print(f"> {website_name.capitalize()} - {id}\n  - {currency} {price}\n  - {date}")
+
+
+def print_all_products():
+    records_data = Filemanager.get_record_data()
+
+    print("\n----- SHOWING ALL PRODUCTS -----")
+    for category_name, category_dict in records_data.items():
+        print(category_name.upper())
+        for product_name, product_dict in category_dict.items():
+            print(f"  > {product_name.upper()}")
+            for website_name, website_dict in product_dict.items():
+                product_id = website_dict["info"]["id"]
+                print(f"    - {website_name.upper()} - {product_id}")
+    print()

--- a/scraper/print_products.py
+++ b/scraper/print_products.py
@@ -1,9 +1,9 @@
-from typing import Iterator, List, Tuple
+from typing import Iterator
 
 from scraper.filemanager import Filemanager
 
 
-def print_latest_datapoints(names: List[str], ids: List[str]) -> None:
+def print_latest_datapoints(names: list[str], ids: list[str]) -> None:
     records_data = Filemanager.get_record_data()
 
     if names:
@@ -24,7 +24,7 @@ def print_latest_datapoints(names: List[str], ids: List[str]) -> None:
             print()
 
 
-def get_product_info_with_name(name: str, records_data: dict) -> Iterator[Tuple[str, str, dict]]:
+def get_product_info_with_name(name: str, records_data: dict) -> Iterator[tuple[str, str, dict]]:
     for category_dict in records_data.values():
         for product_name, product_dict in category_dict.items():
             if not product_name.lower() == name.lower():
@@ -33,7 +33,7 @@ def get_product_info_with_name(name: str, records_data: dict) -> Iterator[Tuple[
                 yield website_name, website_dict
 
 
-def get_product_info_with_id(id: str, records_data: dict) -> Tuple[str, str, dict]:
+def get_product_info_with_id(id: str, records_data: dict) -> tuple[str, str, dict]:
     for category_dict in records_data.values():
         for product_name, product_dict in category_dict.items():
             for website_name, website_dict in product_dict.items():

--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -1,4 +1,3 @@
-from typing import List
 import time
 import threading
 import logging
@@ -75,7 +74,7 @@ def add_product_datapoint(product_data: dict, price: float) -> None:
         product_datapoints.append(new_datapoint)
 
 
-def start_threads_sequentially(threads: List[threading.Thread], request_delay: int) -> None:
+def start_threads_sequentially(threads: list[threading.Thread], request_delay: int) -> None:
     for thread in threads:
         thread.start()
         thread.join()

--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -1,3 +1,6 @@
+from typing import List
+import time
+import threading
 import logging
 from datetime import datetime
 from scraper.domains import BaseWebsiteHandler, get_website_handler
@@ -70,3 +73,9 @@ def add_product_datapoint(product_data: dict, price: float) -> None:
         latest_datapoint["price"] = price
     else:
         product_datapoints.append(new_datapoint)
+
+
+def start_threads_sequentially(threads: List[threading.Thread], request_delay: int) -> None:
+    for thread in threads:
+        thread.start()
+        time.sleep(request_delay)

--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -78,4 +78,5 @@ def add_product_datapoint(product_data: dict, price: float) -> None:
 def start_threads_sequentially(threads: List[threading.Thread], request_delay: int) -> None:
     for thread in threads:
         thread.start()
+        thread.join()
         time.sleep(request_delay)


### PR DESCRIPTION
Update so that scraping at different domains can happen at the same time, but scraping a each domain is sequentially

E.g. if there is four products to be scraped from two different domains, then one product from each domain is scraped at the same time, then after the request_delay the next product from each domain is being scraped at the same time.