### PR TITLE
Raise exception when url has no schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This is equivalent to the above:
 python3 main.py -a -c <category> <category2> -u <url> <url2>
 ```
 
-**OBS**: The url must have the ```https://``` part.<br/>
+**OBS**: The url must have a schema like: ```https://``` or ```http://```.<br/>
 **OBS**: If an error occures when adding a product, then the error might happen because the url has a ```&``` in it, when this happens then just put quotation marks around the url. This should solve the problem. If this doesn't solve the problem then summit a issue.<br/>
 
 <br/>

--- a/scraper/add_product.py
+++ b/scraper/add_product.py
@@ -1,16 +1,17 @@
 from typing import List
 import logging
-from scraper.exceptions import WebsiteNotSupported
+from scraper.exceptions import WebsiteNotSupported, URLMissingSchema
 from scraper.scrape import Scraper
 from scraper.filemanager import Filemanager
 from scraper.domains import get_website_name, SUPPORTED_DOMAINS
+from scraper.constants import URL_SCHEMES
 
 
 def add_products(categories: List[str], urls: List[str]):
     for category, url in zip(categories, urls):
         try:
             add_product(category, url)
-        except WebsiteNotSupported as err:
+        except (WebsiteNotSupported, URLMissingSchema) as err:
             logging.getLogger(__name__).error(err)
             print(err)
 
@@ -22,6 +23,9 @@ def add_product(category: str, url: str) -> None:
 
     if website_name not in SUPPORTED_DOMAINS.keys():
         raise WebsiteNotSupported(website_name)
+
+    if is_missing_url_schema(url):
+        raise URLMissingSchema(url)
 
     print(f"Adding product with category '{category}' and url '{url[0:min(50, len(url))]}'...")
     logger.info(f"Adding product with category '{category}' and url '{url}'")
@@ -98,3 +102,7 @@ def check_if_product_exists_csv(product: Scraper):
             return True
 
     return False
+
+
+def is_missing_url_schema(url: str) -> bool:
+    return not any(schema in url for schema in URL_SCHEMES)

--- a/scraper/constants.py
+++ b/scraper/constants.py
@@ -5,7 +5,6 @@ REQUEST_HEADER = {
 
 REQUEST_COOKIES = {"cookies_are": "working"}
 
-
 WEBSITE_COLORS = {
     "komplett": "orange",
     "proshop": "red",
@@ -23,3 +22,5 @@ WEBSITE_COLORS = {
     "newegg": "#f7c20a",
     "hifiklubben": "#231f20",
 }
+
+URL_SCHEMES = ("http://", "https://")

--- a/scraper/exceptions.py
+++ b/scraper/exceptions.py
@@ -1,3 +1,6 @@
+from scraper.constants import URL_SCHEMES
+
+
 class WebsiteNotSupported(Exception):
     def __init__(self, website_name: str, *args: object) -> None:
         super().__init__(*args)
@@ -5,3 +8,12 @@ class WebsiteNotSupported(Exception):
 
     def __str__(self) -> str:
         return f"Website '{self.website_name}' is currently not supported"
+
+
+class URLMissingSchema(Exception):
+    def __init__(self, url, *args: object) -> None:
+        super().__init__(*args)
+        self.url = url
+
+    def __str__(self) -> str:
+        return f"Missing schema in url '{self.url}'. Consider prefixing the url with one of following schemes: {', '.join(URL_SCHEMES)}"


### PR DESCRIPTION
Add exception ```URLMissingSchema```
Add constant ```URL_SCHEMES```

Update ```add_product.py```:
- Add function ```is_missing_url_schema```
- Update function ```add_products``` to capture exception ```URLMissingSchema```
- Update function ```add_product``` to check if url has schema and raise exception ```URLMissingSchema``` if not