### PR TITLE
Move request timeout to settings.ini

### DIFF
--- a/scraper/domains.py
+++ b/scraper/domains.py
@@ -6,11 +6,14 @@ import logging
 from abc import ABC, abstractmethod
 from scraper.format import Format, Info
 from scraper.constants import REQUEST_HEADER, REQUEST_COOKIES
+from scraper.filemanager import Config
 
 
 def request_url(url: str) -> requests.Response:
+    request_timeout = Config.get_request_timeout()
+
     try:
-        response = requests.get(url, headers=REQUEST_HEADER, cookies=REQUEST_COOKIES, timeout=10)
+        response = requests.get(url, headers=REQUEST_HEADER, cookies=REQUEST_COOKIES, timeout=request_timeout)
         return response
     except requests.RequestException:
         logging.getLogger(__name__).exception(f"Module requests exception with url: {url}")

--- a/scraper/filemanager.py
+++ b/scraper/filemanager.py
@@ -95,3 +95,13 @@ class Config:
     def get_request_delay() -> int:
         config = Config.read(Filemanager.settings_ini_path)
         return int(config["Scraping"]["request_delay"])
+
+    @staticmethod
+    def get_request_timeout() -> float | None:
+        """Get request timeout - if number return float else return None"""
+        config = Config.read(Filemanager.settings_ini_path)
+        timeout = config["Scraping"]["request_timeout"]
+        try:
+            return float(timeout)
+        except ValueError:
+            return None

--- a/scraper/settings.ini
+++ b/scraper/settings.ini
@@ -6,3 +6,5 @@ value1 = asus geforce rtx 3080 rog strix oc
 [Scraping]
 ; request_delay in seconds
 request_delay = 0
+; request_timeout in seconds or None (indefinitely)
+request_timeout = 25

--- a/scraper/settings.ini
+++ b/scraper/settings.ini
@@ -6,5 +6,5 @@ value1 = asus geforce rtx 3080 rog strix oc
 [Scraping]
 ; request_delay in seconds
 request_delay = 0
-; request_timeout in seconds or None (indefinitely)
+; request_timeout in seconds or None for indefinitely
 request_timeout = 25


### PR DESCRIPTION
Add field ```request_timeout``` under section ```Scraping``` in config file ```settings.ini```
<br/>

Add static method ```Config.get_request_timeout``` to get request timeout from config file ```settings.ini```
- if ```request_timeout``` is not a number then return None

Issue: #202 